### PR TITLE
Adding in missing platform css file and fixing paths in html

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -16,7 +16,8 @@
       "mobile": false,
       "styles": [
         "styles.scss",
-        "theme.scss"
+        "theme.scss",
+        "../node_modules/@covalent/core/styles/platform.css"
       ],
       "scripts": [
         "../node_modules/hammerjs/hammer.min.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,9 +2,27 @@
 
 var gulp = require('gulp-help')(require('gulp'));
 var config = require('../build.conf');
+var path = require('path');
 
 gulp.task('build', 'Copy the electron files', function() {
   return gulp
-    .src(config.paths.electronrequiredfiles)
-    .pipe(gulp.dest('dist/'));
+    .src(config.paths.electronrequiredfiles, {base: "."})
+    .pipe(gulp.dest(function(file) {
+      // Doing a bunch of chopping up of the paths to get it to copy
+      // into the dist dir correctly
+      // First get the directory one up from scripts dir
+      var parentPath = __dirname.split('/');
+      parentPath.pop();
+      parentPath = parentPath.join('/');
+      // Now lets get rid of everything up to where the assets are
+      var filePath = file.path.split(parentPath)[1];
+      // Git rid of the filename from the path
+      var splitPath = filePath.split('/');
+      filePath = splitPath.slice(2).join('/');
+      filePath = filePath.substring(0, filePath.lastIndexOf("/"));
+      // Now override the filepath to only be the name
+      file.path = path.basename(file.path);
+      // Return back the Path we chopped up above
+      return  'dist/' + filePath;
+    }));
 });

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,6 +1,6 @@
 <td-layout-card-over>
   <div layout="row" layout-align="start center">
-    <md-icon class="md-icon-svg-lg" svgSrc="/icons/covalent.svg"></md-icon>
+    <md-icon class="md-icon-svg-lg" svgSrc="app/assets/icons/covalent.svg"></md-icon>
     <div>
       <md-card-title>Teradata Electron Covalent UI Platform</md-card-title>
     <md-card-subtitle>built on Teradata Covalent</md-card-subtitle>

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
 <body>
   <app-covalent>
     <div style="padding: 20%;text-align:center;">
-      <img src="/icons/covalent.svg" width="100">
+      <img src="app/assets/icons/covalent.svg" width="100">
       <h3>Covalent Electron Loading...</h3>
     </div>
   </app-covalent>


### PR DESCRIPTION
## Description

Adding in missing platform css file and fixing so path in html work the same for doing ng serve or for running in Electron

### What's included?

- angular-cli.json
- scripts/build.js
- src/app/components/home/home.component.html
- src/index.html

#### Test Steps

- [ ] do a npm run package and see css and links work
- [ ] for example a link like img src="app/assets/icons/covalent.svg"
- [ ] do a ng serve and also see that the css and links work 
- [ ] for example a link like img src="app/assets/icons/covalent.svg"
