### PR TITLE
feat(packaging): added windows support + upgraded CLI to use assets property

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -7,7 +7,10 @@
     {
       "root": "src",
       "outDir": "dist",
-      "assets": "assets",
+      "assets": [
+        "app/assets",
+        "favicon.ico"
+      ],
       "index": "index.html",
       "main": "main.ts",
       "test": "test.ts",

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -8,8 +8,7 @@
       "root": "src",
       "outDir": "dist",
       "assets": [
-        "app/assets",
-        "favicon.ico"
+        "app/assets"
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/build.conf.js
+++ b/build.conf.js
@@ -3,8 +3,7 @@
 module.exports = {
   paths: {
     electronrequiredfiles: [
-      'electron/**',
-      'src/app/assets/**'
+      'electron/**'
     ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tslint": "tslint -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
     "ngbuild": "rm -rf ./dist && ng build",
     "build": "gulp copy",
-    "package": "npm run ngbuild && npm run build && ./node_modules/electron-packager/cli.js dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite"
+    "package": "npm run ngbuild && npm run build && node \"./node_modules/electron-packager/cli.js\" dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite"
   },
   "engines": {
     "node": ">4.4 < 7",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,19 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
+    "@angular/common": "2.2.1",
+    "@angular/compiler": "2.2.1",
+    "@angular/core": "2.2.1",
+    "@angular/forms": "2.2.1",
+    "@angular/http": "2.2.1",
+    "@angular/material": "2.0.0-alpha.10",
+    "@angular/platform-browser": "2.2.1",
+    "@angular/platform-browser-dynamic": "2.2.1",
+    "@angular/platform-server": "2.2.1",
+    "@angular/router": "3.2.1",
+    "@covalent/charts": "0.9.1",
     "@covalent/chips": "0.9.1",
     "@covalent/core": "0.9.1",
-    "@covalent/charts": "0.9.1",
     "@covalent/data-table": "0.9.1",
     "@covalent/file-upload": "0.9.1",
     "@covalent/highlight": "0.9.1",
@@ -52,12 +62,12 @@
     "ts-helpers": "^1.1.1"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "0.6.1",
+    "@angular/compiler-cli": "2.2.1",
     "@types/hammerjs": "^2.0.30",
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.34",
     "@types/selenium-webdriver": "^2.52.0",
-    "angular-cli": "1.0.0-beta.15",
+    "angular-cli": "1.0.0-beta.19-3",
     "codelyzer": "~0.0.26",
     "awesome-typescript-loader": "^2.2.4",
     "ember-cli-inject-live-reload": "1.4.0",
@@ -68,7 +78,7 @@
     "semver": "5.2.0",
     "ts-node": "1.2.1",
     "tslint": "^3.15.1",
-    "typescript": "2.0.2",
+    "typescript": "2.0.10",
     "electron": "^1.4.4",
     "electron-packager": "^8.1.0"
   }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -10,7 +10,7 @@
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue.
 $primary: md-palette($md-orange, 800);
-$accent:  md-palette($md-light-blue, 900, A100, A400);
+$accent:  md-palette($md-light-blue, 600, A100, A400);
 
 // The warn palette is optional (defaults to red).
 $warn:    md-palette($md-red, 600);


### PR DESCRIPTION
### Description

Leveraged angular-cli to copy assets and added windows support to the electron packaging build.

### Tests

- [ ] install angular-cli 19-3
- [ ] `npm i`
- [ ] `npm run package`