### PR TITLE
Fixing bug where moving Window after live-reload causes error

### DIFF
--- a/src/electron-load.js
+++ b/src/electron-load.js
@@ -11,6 +11,7 @@ module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules
 if (electron.remote.process.env.LIVE_UPDATE === "true") {
     client = require('electron-connect').client.create();
     client.on("reloadit", function() {
+      electron.remote.getCurrentWindow().removeAllListeners();
       electron.remote.getCurrentWindow().loadURL(url.format({
             pathname: 'index.html',
             protocol: 'file:',


### PR DESCRIPTION
## Description

Fixing bug with live-reload where after reload moving the app window causes an error.  Need to release all the callback listeners before reloading

### What's included?

- src/electron-load.js

#### Test Steps

- []  run `npm run live-update`
- []  make a change in home.component.html
- []  see that the live-update is successful
- []  now move the window of the application around with the mouse and let go
- []  the error is no longer shown
