### PR TITLE
bugfix(monaco): monaco in windows.

### DIFF
--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -10,7 +10,7 @@ import { Subject } from 'rxjs/Subject';
 export class TdMonacoEditorComponent implements OnInit {
 
   private _editorStyle: string = 'border:1px solid grey;';
-  private _appPath: string = electron.remote.app.getAppPath();
+  private _appPath: string = electron.remote.app.getAppPath().split('\\').join('/');
   private _webview: any;
   private _value: string = '';
   private _theme: string = 'vs';


### PR DESCRIPTION
### Description
Replaced `\` with `/` in appPath for file loading in windows

### Test Steps
- [ ] `npm run live-reload` in windows
- [ ] `npm run live-reload` in mac to see it still working
- [ ] See monaco load and play with demo