### PR TITLE
File Select History Navigation (Back and Forward buttons) and correct file name display

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -28,7 +28,7 @@
                                 </md-button-toggle-group>
                             </div>
                             <div flex layout="column" class="md-content">
-                                <td-file-select (openFile)="monaco.value = $event"></td-file-select>
+                                <td-file-select #fileSelect (openFile)="monaco.value = $event.contents"></td-file-select>
                             </div>
                         </div>
                     </div>
@@ -82,7 +82,7 @@
                     <div layout="row" layout-align="start center">
                         <span class="push-left">
                             <md-icon class="text-md">description</md-icon>
-                            <span>local/my queries/filename.sql</span>
+                            <span>{{fileSelect.currentOpenedFile ? fileSelect.currentOpenedFile.path + fileSelect.currentOpenedFile.name : 'no selected file'}}</span>
                         </span>
                         <span flex></span>
                         <span class="push-left">

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -79,7 +79,7 @@
                     </div>
                 </div>
                 <div class="td-layout-footer bgc-black pad-xs">
-                    <div layout="row" layout-align="start center">
+                    <div layout="row" class="pad-sm" layout-align="start center">
                         <span class="push-left">
                             <md-icon class="text-md">description</md-icon>
                             <span>{{fileSelect.currentOpenedFile ? fileSelect.currentOpenedFile.path + fileSelect.currentOpenedFile.name : 'no selected file'}}</span>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -28,14 +28,9 @@
                                 </md-button-toggle-group>
                             </div>
                             <div flex layout="column" class="md-content">
-                                <td-file-select #fileSelect (openFile)="monaco.value = $event.contents"></td-file-select>
+                                <td-file-select layout="column" flex #fileSelect (openFile)="monaco.value = $event.contents"></td-file-select>
                             </div>
                         </div>
-                    </div>
-                    <div class="td-layout-footer bgc-black pad-xs" layout="row">
-                        <button md-icon-button><md-icon>add</md-icon></button>
-                        <span flex></span>
-                        <button md-icon-button><md-icon>refresh</md-icon></button>
                     </div>
                 </div>
             </md-sidenav>

--- a/src/platform/file-select/file-select.component.html
+++ b/src/platform/file-select/file-select.component.html
@@ -1,7 +1,12 @@
 <md-nav-list dense>
     <h3 md-subheader>Browse Files</h3>
+    <div layout="row" layout-align="space-around center">
+      <button md-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>keyboard_arrow_left</md-icon>Back</button>
+      <button md-button [disabled]="!canShowNext()"(click)="nextPage()">Forward<md-icon>keyboard_arrow_right</md-icon></button>
+    </div>
+    <md-divider></md-divider>
     <template let-file let-last="last" ngFor [ngForOf]="files">
-        <a md-list-item class="directory text-truncate" (click)="loadFiles(file.name)">
+        <a md-list-item class="directory text-truncate" (click)="loadFiles(file.name, true)">
             <md-icon md-list-icon>{{file.icon}}</md-icon> {{file.name}}
         </a>
         <md-divider *ngIf="!last"></md-divider>

--- a/src/platform/file-select/file-select.component.html
+++ b/src/platform/file-select/file-select.component.html
@@ -1,10 +1,8 @@
-<md-nav-list dense>
-    <h3 md-subheader>Browse Files</h3>
-    <div layout="row" layout-align="space-around center">
-      <button md-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>keyboard_arrow_left</md-icon>Back</button>
-      <button md-button [disabled]="!canShowNext()"(click)="nextPage()">Forward<md-icon>keyboard_arrow_right</md-icon></button>
-    </div>
-    <md-divider></md-divider>
+<div layout="row" layout-align="start center" class="bgc-grey-900">
+    <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>arrow_back</md-icon></button><span class="md-title">Browse Files</span>
+</div>
+<md-divider></md-divider>
+<md-nav-list dense flex>
     <template let-file let-last="last" ngFor [ngForOf]="files">
         <a md-list-item class="directory text-truncate" (click)="loadFiles(file.name, true)">
             <md-icon md-list-icon>{{file.icon}}</md-icon> {{file.name}}
@@ -12,3 +10,10 @@
         <md-divider *ngIf="!last"></md-divider>
     </template>
 </md-nav-list>
+<md-divider></md-divider>
+<td-layout-footer-inner>
+    <div layout="row" layout-align="start center">
+        <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>keyboard_arrow_left</md-icon></button>
+        <button md-icon-button [disabled]="!canShowNext()"(click)="nextPage()"><md-icon>keyboard_arrow_right</md-icon></button>
+    </div>
+</td-layout-footer-inner>

--- a/src/platform/file-select/file-select.component.html
+++ b/src/platform/file-select/file-select.component.html
@@ -1,19 +1,22 @@
-<div layout="row" layout-align="start center" class="bgc-grey-900">
-    <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>arrow_back</md-icon></button><span class="md-title">Browse Files</span>
+<div layout="row" layout-align="start center" class="bgc-black">
+    <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()">
+        <md-icon *ngIf="canShowPrevious()">arrow_back</md-icon>
+    </button>
+    <span class="md-subhead">Browse Files</span>
 </div>
 <md-divider></md-divider>
-<md-nav-list dense flex>
-    <template let-file let-last="last" ngFor [ngForOf]="files">
-        <a md-list-item class="directory text-truncate" (click)="loadFiles(file.name, true)">
-            <md-icon md-list-icon>{{file.icon}}</md-icon> {{file.name}}
-        </a>
-        <md-divider *ngIf="!last"></md-divider>
-    </template>
-</md-nav-list>
+<div flex class="md-content">
+    <md-nav-list dense>
+        <template let-file let-last="last" ngFor [ngForOf]="files">
+            <a md-list-item class="directory text-truncate" (click)="loadFiles(file.name, true)">
+                <md-icon md-list-icon>{{file.icon}}</md-icon> {{file.name}}
+            </a>
+            <md-divider *ngIf="!last"></md-divider>
+        </template>
+    </md-nav-list>
+</div>
 <md-divider></md-divider>
-<td-layout-footer-inner>
-    <div layout="row" layout-align="start center">
-        <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>keyboard_arrow_left</md-icon></button>
-        <button md-icon-button [disabled]="!canShowNext()"(click)="nextPage()"><md-icon>keyboard_arrow_right</md-icon></button>
-    </div>
-</td-layout-footer-inner>
+<div class="td-layout-footer bgc-black pad-xs" layout="row" layout-align="end">
+    <button md-icon-button [disabled]="!canShowPrevious()" (click)="previousPage()"><md-icon>keyboard_arrow_left</md-icon></button>
+    <button md-icon-button [disabled]="!canShowNext()"(click)="nextPage()"><md-icon>keyboard_arrow_right</md-icon></button>
+</div>

--- a/src/platform/file-select/file-select.component.scss
+++ b/src/platform/file-select/file-select.component.scss
@@ -1,3 +1,0 @@
-:host {
-    display:block;
-}

--- a/src/platform/file-select/file-select.component.ts
+++ b/src/platform/file-select/file-select.component.ts
@@ -5,6 +5,7 @@ export interface IFile {
   name: string;
   icon: string;
   expansion_visible: boolean;
+  contents?: string;
 }
 
 @Component({
@@ -16,20 +17,24 @@ export class TdFileSelectComponent implements AfterViewInit {
 
     files: IFile[] = [];
     prevPath: string = '';
+    currentOpenedFile: IFile;
+    pathHistory: string[] = [];
+    pathFuture: string[] = [];
+    homeDir: string = '';
 
    /**
     * onOpenFileContents: function($event)
     * Event emitted when a file is opened
     */
-    @Output('openFile') openFile: EventEmitter<string> = new EventEmitter<string>();
+    @Output('openFile') openFile: EventEmitter<IFile> = new EventEmitter<IFile>();
 
     ngAfterViewInit(): void {
         // get the node.js "process" object
         let process: any  = electron.remote.process;
         // get the home dir from the process object environment variables
-        let homeDir: string = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-        this.prevPath = homeDir;
-        this.loadFiles('');
+        this.homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+        this.prevPath = this.homeDir;
+        this.loadFiles('', true);
     }
 
   /**
@@ -37,7 +42,7 @@ export class TdFileSelectComponent implements AfterViewInit {
    * and try to traverse down it to find more files and directories
    * If it is a file then it will get the File Contents
    */
-  loadFiles(pathEnd: string): void {
+  loadFiles(pathEnd: string, clearFuture: boolean): void {
     // append the end of the path to the previous directories that have been traversed
     let newPath: string = path.join(this.prevPath, pathEnd);
     // If it is a directory get traverse more
@@ -54,11 +59,62 @@ export class TdFileSelectComponent implements AfterViewInit {
         this.files.push(fileObj);
       }
       this.prevPath = newPath;
+      this.pathHistory.push(this.prevPath);
+      if (clearFuture) {
+        this.pathFuture = [];
+      }
     // If it is a file then create a dynamic expansion panel and 
     // load in the size and modified date and file contents
     } else {
       let fileContents: string = fs.readFileSync(newPath, 'utf8');
-      this.openFile.emit(fileContents);
+      let file: IFile = {
+        path: newPath.slice(0, newPath.lastIndexOf('/')),
+        name: newPath.slice(newPath.lastIndexOf('/')),
+        icon: 'description',
+        expansion_visible: false,
+        contents: fileContents,
+      };
+      this.currentOpenedFile = file;
+      this.openFile.emit(file);
     }
+  }
+
+  /**
+   * nextPage method to move forward in history of file traversion
+   */
+  nextPage(): void {
+    // remove the path from future
+    let futurePath: string = this.pathFuture.pop();
+    // go to the future path
+    this.prevPath = futurePath;
+    this.loadFiles('', false);
+  }
+
+  /**
+   * previousPage method to move backward in history of file traversion
+   */
+  previousPage(): void {
+    // remove the current path from history
+    let currentPath: string = this.pathHistory.pop();
+    // add the current path to the future
+    this.pathFuture.push(currentPath);
+    // remove the previous path from history and then go to it
+    let previousPath: string = this.pathHistory.pop();
+    this.prevPath = previousPath;
+    this.loadFiles('', false);
+  }
+
+  /**
+   * canShowPrevious method to determine if there are previous results that could be shown
+   */
+  canShowPrevious(): boolean {
+    return (this.pathHistory.length > 1);
+  }
+
+  /**
+   * canShowNext method to determine if there are more results that could be shown
+   */
+  canShowNext(): boolean {
+    return (this.pathFuture.length > 0);
   }
 }


### PR DESCRIPTION
## Description

Adding file display to be connected to actual file opened and now have a Back and Forward button to go back and forth between a history of directories the user has selected

### What's included?

- modified:   src/app/components/home/home.component.html
- modified:   src/platform/file-select/file-select.component.html
- modified:   src/platform/file-select/file-select.component.ts

#### Test Steps

- [x]  npm run live-reload
- [x] traverse down file chooser in left bar and select a file
- [x] see the file name display down in the footer
- [x] click the back and forward buttons under Browse
- [x] see that you can correctly go back and forth in the history of what you selected
- [x] see that the buttons disable when there is no where to go back or forward

##### Screenshots
Back and Forward buttons
<img width="317" alt="screen shot 2017-01-18 at 4 19 00 pm" src="https://cloud.githubusercontent.com/assets/10502797/22088582/fb4000d2-dd99-11e6-8967-235ef8ef54eb.png">

Correct Filename shown
<img width="581" alt="screen shot 2017-01-18 at 4 19 44 pm" src="https://cloud.githubusercontent.com/assets/10502797/22088586/00efbe82-dd9a-11e6-9afa-b9badbc6e08d.png">

