### PR TITLE
Fix for double scrollbars when scrolling editor and no scrollbars when resize window

### DIFF
--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -107,7 +107,7 @@ export class TdMonacoEditorComponent implements OnInit {
             <link rel="stylesheet" data-name="vs/editor/editor.main" 
                 href="file:///node_modules/monaco-editor/min/vs/editor/editor.main.css">
         </head>
-        <body style="height:100%">
+        <body style="height:100%;width: 100%;margin: 0;padding: 0;overflow: hidden;">
         <div id="container" style="width:100%;height:100%;${this._editorStyle}"></div>
         <script>
             // Get the ipcRenderer of electron for communication
@@ -192,6 +192,12 @@ export class TdMonacoEditorComponent implements OnInit {
                 css.type = "text/css";
                 css.innerHTML = data.monarchTokensProviderCSS;
                 document.body.appendChild(css);
+            });
+
+            // need to manually resize the editor any time the window size
+            // changes. See: https://github.com/Microsoft/monaco-editor/issues/28
+            window.addEventListener("resize", function resizeEditor() {
+                editor.layout();
             });
         </script>
         </body>


### PR DESCRIPTION
## Description

When scrolling to bottom of an opened file in the editor double scrollbars would appear.  See screenshot.  Also when resizing the window the scrollbars would disappear all together, see:
https://github.com/Microsoft/monaco-editor/issues/28

### What's included?

- modified:   src/platform/monaco-editor/monaco-editor.component.ts

#### Test Steps

- [x] npm run live-reload
- [x] open a file in the editor
- [x] scroll down to the bottom of the file
- [x] should no longer see double scrollbars, just the Monaco styled scrollbars
- [x] resize the whole window
- [x] should still see the scrollbars after resize

##### Screenshots
Double Scrollbars:
<img width="185" alt="screen shot 2017-01-20 at 12 32 15 pm" src="https://cloud.githubusercontent.com/assets/10502797/22164818/ae3782e0-df0d-11e6-8a1e-6e93d665c688.png">

No scrollbars after resize:
<img width="652" alt="screen shot 2017-01-20 at 12 33 13 pm" src="https://cloud.githubusercontent.com/assets/10502797/22164831/c2931740-df0d-11e6-8211-3f430b7df6c1.png">
