### PR TITLE
Upgrade monaco editor to 0.8.0

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -26,7 +26,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "monaco-editor": "^0.7.0"
+    "monaco-editor": "^0.8.0"
   },
   "devDependencies": {
     "electron": "^1.4.1"

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -34,6 +34,19 @@ export class HomeComponent implements AfterViewInit {
           ['/\\[info.*/', 'custom-info'],
           ['/\\[[a-zA-Z 0-9:]+\\]/', 'custom-date'],
       ],
+      customTheme: {
+        id: 'myCustomTheme',
+        theme: {
+          base: 'vs-dark',
+          inherit: true,
+          rules: [
+            { token: 'custom-info', foreground: '808080' },
+            { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
+            { token: 'custom-notice', foreground: 'FFA500' },
+            { token: 'custom-date', foreground: '008800' },
+          ],
+        },
+      },
       monarchTokensProviderCSS: `
         .monaco-editor .token.custom-info {
           color: grey;
@@ -75,6 +88,7 @@ export class HomeComponent implements AfterViewInit {
       ],
     };
     monacoEditor.registerLanguage(language);
+    monacoEditor.theme = 'myCustomTheme';
     monacoEditor.language = 'mySpecialLanguage';
   }
 }

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -182,6 +182,10 @@ export class TdMonacoEditorComponent implements OnInit {
                     }
                 });
 
+                // Define a new theme that constains only rules that match this language
+                monaco.editor.defineTheme(data.customTheme.id, data.customTheme.theme);
+                theme = data.customTheme.id;
+
                 monaco.languages.registerCompletionItemProvider(data.id, {
                     provideCompletionItems: () => {
                         return data.completionItemProvider


### PR DESCRIPTION
## Description

Upgrading monaco editor to 0.8.0 and using new custom themes

### What's included?

- modified:   electron/package.json
- modified:   src/app/components/home/home.component.ts
- modified:   src/platform/monaco-editor/monaco-editor.component.ts

#### Test Steps

- [ ] rm -rf node_modules
- [ ] npm i
- [ ] npm run live-reload
- [ ] try all the options under the triple dot button with the editor (except settings_
- [ ] see works

##### Screenshots
<img width="551" alt="screen shot 2017-01-23 at 2 01 08 pm" src="https://cloud.githubusercontent.com/assets/10502797/22224710/6ae4926c-e174-11e6-822c-1471dbaf594c.png">
