### PR TITLE
 Readme include section about including node_modules in electron app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,39 +33,40 @@ After running the commands below simply save a file in the code base and it will
 Alternatively if you want to also open the Dev Tools while running live-reload run this command instead
 * Create Electron package and run live-reload `npm run live-reload -- --openDevTools`
 
+---
 
 ## Using Node Modules
-To use node_modules in Covalent Electron there are a few steps you need to take.  Covalent is built off of Angular 2 and uses typescript as its coding language.  To allow Node Modules to be used in this framework you will need to follow the steps below.
+To use Node Modules in Covalent Electron there are a few steps you need to take.  Covalent is built off of Angular 2 and uses typescript as its coding language.  To allow Node Modules to be used in this framework with Electron you will need to follow the steps below.
 
 ### Internal Node.js/Electron Node Modules
 
-Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
 `var some_node_module = require('some_node_module');`
 
-Declare this variable in (src/typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module variable. For example:
+* Declare this variable in (typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
 `declare var some_node_module: any;`
 
-Then in your typescript file for your component you should be able to use the node_module directly, for example:
+* Then in your typescript file for your component you should be able to use the node_module directly, for example:
 `some_node_module.xyz();`
 
-After those 4 steps you should be able to use an external node_module.
+After these 3 steps you should be able to use an internal node_module.
 
 
 ### External Node.js/Electron Node Modules
 
-Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
-`var some_node_module = require('some_node_module');`
-
-Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. So you would add:
+* Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. So you would add:
 `"dependencies": { "some_node_module": "^0.0.1" },`
 
-Declare this variable in (src/typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module variable. For example:
+* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+`var some_node_module = require('some_node_module');`
+
+* Declare this variable in (typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
 `declare var some_node_module: any;`
 
-Then in your typescript file for your component you should be able to use the node_module directly, for example:
+* Then in your typescript file for your component you should be able to use the node_module directly, for example:
 `some_node_module.xyz();`
 
-After those 4 steps you should be able to use an external node_module.
+After these 4 steps you should be able to use an external node_module.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,69 +35,35 @@ Alternatively if you want to also open the Dev Tools while running live-reload r
 
 ---
 
-## Using Node Modules
-To use Node Modules in Covalent Electron there are a few steps you need to take.  Covalent is built off of Angular 2 and uses typescript as its coding language.  To allow Node Modules to be used in this framework with Electron you will need to follow the steps below.
+## Including Node Modules in Covalent Electron
+To utilize "internal" (eg. fs, path, etc.) or "3rd party" (eg. winston, uuid, etc.) node modules from within your Covalent Electron application, you must perform the following steps to ensure the node modules are accessible. Assume for this example you want to utilize a node module named "some_node_module".
 
-### Internal Node.js/Electron Node Modules
+1. Add the require for the module in [src/electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) in the below location
 
-* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
-
-`var some_node_module = require('some_node_module');`
-
- Make sure to require this after the section:
 ```
 /*
  * Require external node modules here
  */
+ var some_node_module = require('some_node_module');
 ```
-This is because the line above:
+Make sure it is below the line:
 
 `module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));`
 
-is what makes the node_modules available to electron
+This line is where the node_modules directory becomes available to electron
 
-* Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
+2. Declare a corresponding variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts) to ensure the compiler does not complain about references to the module in Typescript.
 
 `declare var some_node_module: any;`
 
-* Then in your typescript file for your component you should be able to use the node_module directly, for example:
-
-`some_node_module.xyz();`
-
-After these 3 steps you should be able to use an internal node_module.
-
-
-### External Node.js/Electron Node Modules
-
-* Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. For example, if you had a node_module called "some_node_module", then add:
+3. If the node module is a "3rd party" module, include the module as a dependency in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json). This is a separate package.json, differentiated from the top level package.json, that defines modules you want to be accessible in the electron app.
 
 `"dependencies": { "some_node_module": "^0.0.1" },`
 
-* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use.  For example:
 
-`var some_node_module = require('some_node_module');`
-
- Make sure to require this after the section:
-```
-/*
- * Require external node modules here
- */
-```
-This is because the line above:
-
-`module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));`
-
-is what makes the node_modules available to electron
-
-* Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
-
-`declare var some_node_module: any;`
-
-* Then in your typescript file for your component you should be able to use the node_module directly, for example:
+4. In your Typescript, you can now reference the module as follows.
 
 `some_node_module.xyz();`
-
-After these 4 steps you should be able to use an external node_module.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ After these 3 steps you should be able to use an internal node_module.
 
 ### External Node.js/Electron Node Modules
 
-* Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. So you would add:
+* Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. For example, if you had a node_module called "some_node_module", then add:
 
 `"dependencies": { "some_node_module": "^0.0.1" },`
 
-* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+* Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use.  For example:
 
 `var some_node_module = require('some_node_module');`
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ To use Node Modules in Covalent Electron there are a few steps you need to take.
 
 `var some_node_module = require('some_node_module');`
 
+ Make sure to require this after the section:
+```
+/*
+ * Require external node modules here
+ */
+```
+This is because the line above:
+
+`module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));`
+
+is what makes the node_modules available to electron
+
 * Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
 
 `declare var some_node_module: any;`
@@ -64,6 +76,18 @@ After these 3 steps you should be able to use an internal node_module.
 * Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use.  For example:
 
 `var some_node_module = require('some_node_module');`
+
+ Make sure to require this after the section:
+```
+/*
+ * Require external node modules here
+ */
+```
+This is because the line above:
+
+`module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));`
+
+is what makes the node_modules available to electron
 
 * Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use Node Modules in Covalent Electron there are a few steps you need to take.
 * Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
 `var some_node_module = require('some_node_module');`
 
-* Declare this variable in (typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
+* Declare this variable in [src/typings.d.ts][https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
 `declare var some_node_module: any;`
 
 * Then in your typescript file for your component you should be able to use the node_module directly, for example:
@@ -60,7 +60,7 @@ After these 3 steps you should be able to use an internal node_module.
 * Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
 `var some_node_module = require('some_node_module');`
 
-* Declare this variable in (typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
+* Declare this variable in [src/typings.d.ts][https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
 `declare var some_node_module: any;`
 
 * Then in your typescript file for your component you should be able to use the node_module directly, for example:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 <img alt="Covalent" src="https://cdn.rawgit.com/Teradata/covalent-electron/develop/src/app/assets/icons/covalent-and-electron.svg" width="503">
 
 Covalent is a reusable UI platform from Teradata for building web applications with common standards and tooling. It is based on Angular 2 and Material Design.
+
+Covalent Github Repo: https://github.com/Teradata/covalent
+
 Covalent-Electron is the Electron Platform to build desktop apps using Covalent and Electron
 ## Setup
 
@@ -29,6 +32,40 @@ After running the commands below simply save a file in the code base and it will
 
 Alternatively if you want to also open the Dev Tools while running live-reload run this command instead
 * Create Electron package and run live-reload `npm run live-reload -- --openDevTools`
+
+
+## Using Node Modules
+To use node_modules in Covalent Electron there are a few steps you need to take.  Covalent is built off of Angular 2 and uses typescript as its coding language.  To allow Node Modules to be used in this framework you will need to follow the steps below.
+
+### Internal Node.js/Electron Node Modules
+
+Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+`var some_node_module = require('some_node_module');`
+
+Declare this variable in (src/typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module variable. For example:
+`declare var some_node_module: any;`
+
+Then in your typescript file for your component you should be able to use the node_module directly, for example:
+`some_node_module.xyz();`
+
+After those 4 steps you should be able to use an external node_module.
+
+
+### External Node.js/Electron Node Modules
+
+Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+`var some_node_module = require('some_node_module');`
+
+Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. So you would add:
+`"dependencies": { "some_node_module": "^0.0.1" },`
+
+Declare this variable in (src/typings.d.ts)[https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module variable. For example:
+`declare var some_node_module: any;`
+
+Then in your typescript file for your component you should be able to use the node_module directly, for example:
+`some_node_module.xyz();`
+
+After those 4 steps you should be able to use an external node_module.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ To use Node Modules in Covalent Electron there are a few steps you need to take.
 ### Internal Node.js/Electron Node Modules
 
 * Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+
 `var some_node_module = require('some_node_module');`
 
-* Declare this variable in [src/typings.d.ts][https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
+* Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
+
 `declare var some_node_module: any;`
 
 * Then in your typescript file for your component you should be able to use the node_module directly, for example:
+
 `some_node_module.xyz();`
 
 After these 3 steps you should be able to use an internal node_module.
@@ -55,15 +58,19 @@ After these 3 steps you should be able to use an internal node_module.
 ### External Node.js/Electron Node Modules
 
 * Include the module in the [electron/package.json](https://github.com/Teradata/covalent-electron/blob/develop/electron/package.json) dependencies. To note: this is different than the package.json at the top of the source tree. The package.json in electron/package.json is for node_modules you want to actually be included in the electron app. The ones listed in the package.json at the top of the source tree will not be included in the electron app. So you would add:
+
 `"dependencies": { "some_node_module": "^0.0.1" },`
 
 * Add to [electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) the requires for the node_module you want to use, for example, if you had a node_module called "some_node_module", then add:
+
 `var some_node_module = require('some_node_module');`
 
-* Declare this variable in [src/typings.d.ts][https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts]. This will allow typescript to not complain about the use of the node_module. For example:
+* Declare this variable in [src/typings.d.ts](https://github.com/Teradata/covalent-electron/blob/develop/src/typings.d.ts). This will allow typescript to not complain about the use of the node_module. For example:
+
 `declare var some_node_module: any;`
 
 * Then in your typescript file for your component you should be able to use the node_module directly, for example:
+
 `some_node_module.xyz();`
 
 After these 4 steps you should be able to use an external node_module.

--- a/src/electron-load.js
+++ b/src/electron-load.js
@@ -7,6 +7,12 @@ var url = require('url');
 var client;
 // Add all 3rd party node_modules included in the Electron app to be able to be used
 module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));
+
+/*
+* Require external node modules here
+*/
+
+
 // if LIVE_UPDATE env variable is true then use electron-connect
 if (electron.remote.process.env.LIVE_UPDATE === "true") {
     client = require('electron-connect').client.create();


### PR DESCRIPTION
## Description

Updating readme to include section about including node_modules in electron app

### What's included?

- modified:  README.md

#### Test Steps

- [ ] checkout branch feature/readme-external-node_modules
- [ ] See Readme sections for Using Node Modules
- [ ] Verify this makes sense


