### PR TITLE
Fix to allow multiple editors in app

### DIFF
--- a/src/platform/monaco-editor/monaco-editor.component.html
+++ b/src/platform/monaco-editor/monaco-editor.component.html
@@ -1,1 +1,1 @@
-<div id="monacoContainer"></div>
+<div #monacoContainer></div>

--- a/src/platform/monaco-editor/monaco-editor.component.html
+++ b/src/platform/monaco-editor/monaco-editor.component.html
@@ -1,1 +1,1 @@
-<div #monacoContainer></div>
+<div class="monacoContainer" #monacoContainer></div>

--- a/src/platform/monaco-editor/monaco-editor.component.scss
+++ b/src/platform/monaco-editor/monaco-editor.component.scss
@@ -1,7 +1,7 @@
 :host {
     display:block;
 }
-#monacoContainer {
+.monacoContainer {
     width:100%;
     height:98%;
 }

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -1,6 +1,8 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
+
+var uniqueCounter = 0;
 
 @Component({
   selector: 'td-monaco-editor',
@@ -16,6 +18,10 @@ export class TdMonacoEditorComponent implements OnInit {
   private _theme: string = 'vs';
   private _language: string = 'javascript';
   private _subject: Subject<string> = new Subject();
+
+  private _monacoInnerContainer = 'monacoInnerContainer' + uniqueCounter++;
+
+  @ViewChild('monacoContainer') _monacoContainer: ElementRef;
 
  /**
   * editorValueChange: function($event)
@@ -108,7 +114,7 @@ export class TdMonacoEditorComponent implements OnInit {
                 href="file:///node_modules/monaco-editor/min/vs/editor/editor.main.css">
         </head>
         <body style="height:100%;width: 100%;margin: 0;padding: 0;overflow: hidden;">
-        <div id="container" style="width:100%;height:100%;${this._editorStyle}"></div>
+        <div id="${this._monacoInnerContainer}" style="width:100%;height:100%;${this._editorStyle}"></div>
         <script>
             // Get the ipcRenderer of electron for communication
             const {ipcRenderer} = require('electron');
@@ -125,7 +131,7 @@ export class TdMonacoEditorComponent implements OnInit {
             self.process.browser = true;
 
             require(['vs/editor/editor.main'], function() {
-                editor = monaco.editor.create(document.getElementById('container'), {
+                editor = monaco.editor.create(document.getElementById('${this._monacoInnerContainer}'), {
                     value: '${this._value}',
                     language: '${this.language}',
                     theme: '${this._theme}',
@@ -154,7 +160,7 @@ export class TdMonacoEditorComponent implements OnInit {
             ipcRenderer.on('setLanguage', function(event, data){
                 var currentValue = editor.getValue();
                 editor.dispose();
-                editor = monaco.editor.create(document.getElementById('container'), {
+                editor = monaco.editor.create(document.getElementById('${this._monacoInnerContainer}'), {
                     value: currentValue,
                     language: data,
                     theme: theme,
@@ -237,7 +243,6 @@ export class TdMonacoEditorComponent implements OnInit {
     });
 
     // append the webview to the DOM
-    let monacoContainer: HTMLElement = document.getElementById('monacoContainer');
-    monacoContainer.appendChild(this._webview);
+    this._monacoContainer.nativeElement.appendChild(this._webview);
   }
 }

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit, ViewChild, ElementRef }
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
-var uniqueCounter = 0;
+let uniqueCounter: number = 0;
 
 @Component({
   selector: 'td-monaco-editor',
@@ -19,7 +19,7 @@ export class TdMonacoEditorComponent implements OnInit {
   private _language: string = 'javascript';
   private _subject: Subject<string> = new Subject();
 
-  private _monacoInnerContainer = 'monacoInnerContainer' + uniqueCounter++;
+  private _monacoInnerContainer: string = 'monacoInnerContainer' + uniqueCounter++;
 
   @ViewChild('monacoContainer') _monacoContainer: ElementRef;
 


### PR DESCRIPTION
Trying to incorporate multiple editors in a single application is failing because the monaco component is trying to find elements with fixed ids. This pull request proposes a fix that comprises:
1. Derive a unique id for the inner div where the editor is created.
2. Access the outer div where inner HTML will be appended via ViewChild.