### PR TITLE
Use ng build --watch to speed up live-reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /deploy
 /tmp
 /dist-app
+/dist-ng
 
 # dependencies
 /node_modules

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "electron": "^1.5.0",
     "electron-packager": "^8.5.1",
     "electron-connect": "^0.6.1",
-    "run-sequence": "^1.2.2"
+    "run-sequence": "^1.2.2",
+    "chokidar": "^1.6.1"
   }
 }

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -47,7 +47,7 @@ gulp.task('copy-electron-connect', function () {
 
 // copy over the dist-ng dir to the dist dir
 gulp.task('copy-dist-ng', function () {
-    gulp.src(['dist-ng/**'], {base: 'dist-ng/'}).pipe(gulp.dest('dist'));
+    return gulp.src(['dist-ng/**'], {base: 'dist-ng/'}).pipe(gulp.dest('dist'));
 });
 
 // copy over the dist-ng dir to the dist dir and reload electron

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -113,8 +113,8 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       persistent: true,
       ignorePermissionErrors: true,
       atomic: 2000,
-    }).on('change', path => {
-      if (path.indexOf('dist-ng') > -1) {
+    }).on('all', (event, path) => {
+      if (event === 'add' && path.indexOf('dist-ng') > -1) {
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var gulp = require('gulp');
+var chokidar = require('chokidar');
 var spawn = require('child_process').spawn;
 var runSequence = require('run-sequence');
 var electron = require('electron-connect').server.create();
@@ -90,12 +91,13 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
   cmd.on('close', function (code) {
       cb(code);
   });
-  var fs = require('fs');
-  if (!fs.existsSync('dist-ng')){
-      fs.mkdirSync('dist-ng');
-      fs.openSync('dist-ng/fake', 'a')
-  }
-  gulp.watch(['dist-ng/**/*'], ['changes-detected']);
+  chokidar.watch('dist-ng/**/*', {
+    persistent: true,
+  }).on('addDir', function(event, path) {
+    runSequence('changes-detected');
+  }).on('change', function(event, path) {
+    runSequence('changes-detected');
+  });
 });
 
 // check every 3 seconds if ng build has run

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -107,7 +107,6 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
 
     if (!fs.existsSync('dist-ng')){
        fs.mkdirSync('dist-ng');
-       fs.openSync('dist-ng/fake', 'a')
     }
 
     chokidar.watch('.', {

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -114,8 +114,8 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       ignorePermissionErrors: true,
       atomic: 2000,
     }).on('all', (event, path) => {
-      console.log(event + ": " + path);
-      if (event === 'add' && path.indexOf('dist-ng') > -1) {
+      if (path.indexOf('dist-ng') > -1) {
+        console.log(event + ": " + path);
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -114,7 +114,7 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       ignorePermissionErrors: true,
       atomic: 2000,
     }).on('all', (event, path) => {
-      if (path.indexOf('dist-ng') > -1) {
+      if ((event === 'add' || event === 'change') && path.indexOf('dist-ng') > -1) {
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -118,7 +118,7 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
         pollInterval: 100
       },
     }).on('all', (event, path) => {
-      if ((event === 'add' || event === 'change') && path.indexOf('dist-ng') > -1) {
+      if ((event === 'add' || event === 'change') && path.indexOf('main.bundle.js') > -1) {
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -4,6 +4,7 @@ var gulp = require('gulp');
 var chokidar = require('chokidar');
 var spawn = require('child_process').spawn;
 var runSequence = require('run-sequence');
+var fs = require('fs');
 var electron = require('electron-connect').server.create();
 var rendered = false;
 var changesDetected = false;
@@ -84,7 +85,6 @@ gulp.task('reload-electron', function () {
   electron.broadcast("reloadit", "true");
 });
 
-var fs = require('fs');
 var deleteFolderRecursive = function(path) {
   if( fs.existsSync(path) ) {
     fs.readdirSync(path).forEach(function(file,index){
@@ -104,6 +104,11 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
 
   if (/^win/.test(process.platform)) { // windows
     deleteFolderRecursive('dist-ng');
+
+    if (!fs.existsSync('dist-ng')){
+       fs.mkdirSync('dist-ng');
+       fs.openSync('dist-ng/fake', 'a')
+    }
 
     chokidar.watch('.', {
       persistent: true,

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -114,6 +114,7 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       ignorePermissionErrors: true,
       atomic: 2000,
     }).on('all', (event, path) => {
+      console.log(event + ": " + path);
       if (event === 'add' && path.indexOf('dist-ng') > -1) {
         runSequence('changes-detected');
       }

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -115,7 +115,6 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       atomic: 2000,
     }).on('all', (event, path) => {
       if (path.indexOf('dist-ng') > -1) {
-        console.log(event + ": " + path);
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -133,10 +133,10 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
   if (!/^win/.test(process.platform)) { // linux
     chokidar.watch('dist-ng/**/*', {
       persistent: true,
-    }).on('addDir', function(event, path) {
-      runSequence('changes-detected');
-    }).on('change', function(event, path) {
-      runSequence('changes-detected');
+    }).on('all', (event, path) => {
+      if ((event === 'add' || event === 'change') && ((path.indexOf('dist-ng/main.bundle.js') > -1) || (path.indexOf('dist-ng\\main.bundle.js') > -1))) {
+        runSequence('changes-detected');
+      }
     });
   }
 });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -118,7 +118,7 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
         pollInterval: 100
       },
     }).on('all', (event, path) => {
-      if ((event === 'add' || event === 'change') && path.indexOf('main.bundle.js') > -1) {
+      if ((event === 'add' || event === 'change') && ((path.indexOf('dist-ng/main.bundle.js') > -1) || (path.indexOf('dist-ng\\main.bundle.js') > -1))) {
         runSequence('changes-detected');
       }
     });

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -113,6 +113,10 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
       persistent: true,
       ignorePermissionErrors: true,
       atomic: 2000,
+      awaitWriteFinish: {
+        stabilityThreshold: 2000,
+        pollInterval: 100
+      },
     }).on('all', (event, path) => {
       if ((event === 'add' || event === 'change') && path.indexOf('dist-ng') > -1) {
         runSequence('changes-detected');


### PR DESCRIPTION
## Description

Using `ng build --watch` to greatly speed up builds when using live-reload.  Reload times are now 2 or 3 seconds instead of 30 seconds on Mac and 3.5 minutes on Windows.

### What's included?

- modified:   .gitignore
- modified:   scripts/reload.js

#### Test Steps

- [x] checkout feature/use-ng-watch branch
- [x] run `npm run live-reload -- --openDevTools`
- [x] make a change in an html file
- [x] see the live-reload happen in a few seconds instead of minutes

