### PR TITLE
Ability to run Karma Unit Tests in Covalent-Electron

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -13,6 +13,7 @@
       ],
       "index": "index.html",
       "main": "main.ts",
+      "polyfills": "polyfills.ts",
       "test": "test.ts",
       "tsconfig": "tsconfig.json",
       "prefix": "app",
@@ -26,8 +27,8 @@
         "../node_modules/hammerjs/hammer.min.js",
         "../node_modules/showdown/dist/showdown.js"
       ],
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "source": "environments/environment.ts",
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run VsCode and attach as the Debugger to Covalent Electron see here:
 ---
 
 ## Including Node Modules in Covalent Electron
-To utilize "internal" (eg. fs, path, etc.) or "3rd party" (eg. winston, uuid, etc.) node modules from within your Covalent Electron application, you must perform the following steps to ensure the node modules are accessible. Assume for this example you want to utilize a node module named "some_node_module".
+To utilize "internal" (eg. fs, path, etc.) or "3rd party" (eg. winston, uuid, monaco-editor, etc.) node modules from within your Covalent Electron application, you must perform the following steps to ensure the node modules are accessible. Assume for this example you want to utilize a node module named "some_node_module".
 
 1. Add the require for the module in [src/electron-load.js](https://github.com/Teradata/covalent-electron/blob/develop/src/electron-load.js) in the below location
 
@@ -69,6 +69,18 @@ To utilize "internal" (eg. fs, path, etc.) or "3rd party" (eg. winston, uuid, et
 4. In your Typescript, you can now reference the module as follows.
 
     `some_node_module.xyz();`
+
+---
+
+## Running Unit Tests in Covalent Electron
+Covalent Electron utilizes Karma and ng test to execute unit tests inside an Electron Test Harness. The tests can be run against a standalone Angular 2 Component, an Angular 2 component that uses "internal" node modules, or an Angular 2 component that uses "3rd party" (eg. winston, uuid, monaco-editor, etc.) node modules
+
+* Simply Run `npm run test`
+
+* Example Test Files:
+
+  * (https://github.com/Teradata/covalent-electron/blob/develop/src/platform/file-select/file-select.component.spec.ts) 
+  * (https://github.com/Teradata/covalent-electron/blob/develop/src/platform/monaco-editor/monaco-editor.component.spec.ts) 
 
 ---
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function (config) {
       require('@angular/cli/plugins/karma')
     ],
     client:{
-      useIframe: false,
+      useIframe: false, // can't run in iframe if using Electron Webview
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     files: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,49 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/0.13/config/configuration-file.html
+
+// set the current location so can use external node_modules in tests
+process.env['NODE_MODULE_DIR'] = __dirname + "/dist";
+
+module.exports = function (config) {
+  var configuration = {
+    basePath: '.',
+    frameworks: ['jasmine', '@angular/cli'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-electron'),
+      require('@angular/cli/plugins/karma')
+    ],
+    client:{
+      useIframe: false,
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    files: [
+      { pattern: "./karma.shim.js", watched: true, included: true, served: true},
+      { pattern: './src/test.ts', watched: false }
+    ],
+    preprocessors: {
+      './src/test.ts': ['@angular/cli']
+    },
+    angularCli: {
+      config: './.angular-cli.json',
+      environment: 'dev'
+    },
+    mime: {
+      'text/x-typescript': ['ts','tsx']
+    },
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['CustomElectron'],
+    singleRun: false,
+    // Define a custom launcher which inherits from `Electron`
+    customLaunchers: {
+      CustomElectron: {
+        base: 'Electron',
+        flags: ['--show']
+      }
+    }
+  };
+  config.set(configuration);
+};

--- a/karma.shim.js
+++ b/karma.shim.js
@@ -1,0 +1,12 @@
+window.require = window.top.require;
+window.process = window.top.process;
+window.__dirname = window.top.__dirname;
+require("module").globalPaths.push("./node_modules");
+
+// read in electron-load.js
+var fs = require('fs');
+var electron = require('electron');
+electron.remote.process.env.TESTING = "true";
+eval(fs.readFileSync('./src/electron-load.js')+'');
+
+electron.remote.process.env.NODE_MODULE_DIR = process.env['NODE_MODULE_DIR'];

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tslint": "tslint -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
     "ngbuild": "rm -rf ./dist && ng build",
     "npm-install": "npm --prefix ./dist install ./dist --production",
+    "reinstall": "rm -rf node_modules dist dist-ng dist-app && npm i",
     "build": "gulp copy --option noreload",
     "package": "npm run ngbuild && npm run build && npm run npm-install && node \"./node_modules/electron-packager/cli.js\" dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite",
     "live-reload": "gulp watch",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "tslint": "tslint -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
     "ngbuild": "rm -rf ./dist && ng build",
     "npm-install": "npm --prefix ./dist install ./dist --production",
-    "build": "gulp copy",
+    "build": "gulp copy --option noreload",
     "package": "npm run ngbuild && npm run build && npm run npm-install && node \"./node_modules/electron-packager/cli.js\" dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite",
-    "live-reload": "gulp watch"
+    "live-reload": "gulp watch",
+    "test": "npm run build && npm run npm-install && ng test"
   },
   "engines": {
     "node": ">4.4 < 7",
@@ -40,16 +41,16 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@angular/common": "2.4.4",
-    "@angular/compiler": "2.4.4",
-    "@angular/core": "2.4.4",
-    "@angular/forms": "2.4.4",
-    "@angular/http": "2.4.4",
+    "@angular/common": "2.4.5",
+    "@angular/compiler": "2.4.5",
+    "@angular/core": "2.4.5",
+    "@angular/forms": "2.4.5",
+    "@angular/http": "2.4.5",
     "@angular/material": "2.0.0-beta.1",
-    "@angular/platform-browser": "2.4.4",
-    "@angular/platform-browser-dynamic": "2.4.4",
-    "@angular/platform-server": "2.4.4",
-    "@angular/router": "3.4.4",
+    "@angular/platform-browser": "2.4.5",
+    "@angular/platform-browser-dynamic": "2.4.5",
+    "@angular/platform-server": "2.4.5",
+    "@angular/router": "3.4.5",
     "@covalent/core": "1.0.0-beta.1",
     "@covalent/charts": "1.0.0-beta.1",
     "@covalent/dynamic-forms": "1.0.0-beta.1",
@@ -58,12 +59,12 @@
     "@covalent/markdown": "1.0.0-beta.1"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "2.4.4",
+    "@angular/compiler-cli": "2.4.5",
     "@types/hammerjs": "^2.0.30",
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.34",
     "@types/selenium-webdriver": "^2.52.0",
-    "angular-cli": "1.0.0-beta.26",
+    "@angular/cli": "1.0.0-beta.32.3",
     "codelyzer": "2.0.0-beta.4",
     "gulp": "3.9.1",
     "gulp-help": "1.6.1",
@@ -77,6 +78,11 @@
     "electron-packager": "^8.5.1",
     "electron-connect": "^0.6.1",
     "run-sequence": "^1.2.2",
-    "chokidar": "^1.6.1"
+    "chokidar": "^1.6.1",
+    "jasmine-core": "^2.5.2",
+    "karma": "1.2.0",
+    "karma-cli": "^1.0.1",
+    "karma-electron": "^5.1.1",
+    "karma-jasmine": "^1.0.2"
   }
 }

--- a/scripts/reload.js
+++ b/scripts/reload.js
@@ -141,14 +141,16 @@ gulp.task('watch-src', 'Watch for changed files', function (cb) {
   }
 });
 
-// check every 3 seconds if ng build has run
-setInterval(
-  function(){
-    if (changesDetected) {
-      changesDetected = false;
-      runSequence('copy-dist-ng-and-reload');
-    }
-}, 3000);
+if (!process.argv.includes('noreload')) {
+  // check every 3 seconds if ng build has run
+  setInterval(
+    function(){
+      if (changesDetected) {
+        changesDetected = false;
+        runSequence('copy-dist-ng-and-reload');
+      }
+  }, 3000);
+}
 
 // called when an electron file has been changed
 gulp.task('restart', function (cb) {

--- a/src/electron-load.js
+++ b/src/electron-load.js
@@ -5,8 +5,11 @@ var electron = require('electron');
 var path = require('path');
 var url = require('url');
 var client;
+
 // Add all 3rd party node_modules included in the Electron app to be able to be used
-module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));
+if (!electron.remote.process.env.TESTING) {
+    module.paths.push(path.resolve(electron.remote.app.getAppPath() + '/node_modules'));
+}
 
 /*
 * Require external node modules here

--- a/src/platform/file-select/file-select.component.spec.ts
+++ b/src/platform/file-select/file-select.component.spec.ts
@@ -1,0 +1,121 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { CovalentCoreModule } from '@covalent/core';
+import { TdFileSelectComponent } from './file-select.component';
+import { By } from '@angular/platform-browser';
+
+describe('Component: App', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TdFileSelectComponent,
+      ],
+      imports: [
+        CovalentCoreModule.forRoot(),
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should get local files from OS and amount of them should be greater than 0',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(fixture.componentInstance.files.length).toBeGreaterThan(0);
+      });
+  })));
+
+  it('should nextPage of localfiles and amount of them should be greater than 0',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      component.pathFuture.push(component.homeDir);
+      component.prevPath = component.homeDir;
+      component.nextPage();
+      fixture.whenStable().then(() => {
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(fixture.componentInstance.files.length).toBeGreaterThan(0);
+        });
+      });
+  })));
+
+  it('should not be able to Show Previous Button',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      component.pathHistory = [];
+      fixture.whenStable().then(() => {
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(component.canShowPrevious()).toBeFalsy();
+        });
+      });
+  })));
+
+  it('should be able to Show Previous Button',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      component.pathHistory.push(component.homeDir);
+      fixture.whenStable().then(() => {
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(component.canShowPrevious()).toBeTruthy();
+        });
+      });
+  })));
+
+  it('should not be able to Show Next Button',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      component.pathFuture = [];
+      fixture.whenStable().then(() => {
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(component.canShowNext()).toBeFalsy();
+        });
+      });
+  })));
+
+  it('should be able to Show Next Button',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectComponent);
+      let component: TdFileSelectComponent = fixture.debugElement.componentInstance;
+      component.ngAfterViewInit();
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      component.pathFuture.push(component.homeDir);
+      fixture.whenStable().then(() => {
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(component.canShowNext()).toBeTruthy();
+        });
+      });
+  })));
+
+});

--- a/src/platform/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.spec.ts
@@ -1,0 +1,137 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { CovalentCoreModule } from '@covalent/core';
+import { TdMonacoEditorComponent } from './monaco-editor.component';
+import { By } from '@angular/platform-browser';
+
+declare var electron: any;
+
+describe('Component: App', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TdMonacoEditorComponent,
+      ],
+      imports: [
+        CovalentCoreModule.forRoot(),
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should set the editor value and retrieve that same value from editor', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdMonacoEditorComponent);
+      let component: TdMonacoEditorComponent = fixture.debugElement.componentInstance;
+      component.setMonacoNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.onEditorInitialized.subscribe(() => {
+          component.value = 'SELECT * FROM foo;';
+          component.getValue().subscribe((value: string) => {
+              fixture.whenStable().then(() => {
+                  fixture.detectChanges();
+                  fixture.changeDetectorRef.detectChanges();
+                  expect(value).toBe('SELECT * FROM foo;');
+                  done();
+              });
+            });
+          });
+        });
+    })();
+  });
+
+  it('should register a custom language and custom theme and set to custom language', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdMonacoEditorComponent);
+      let component: TdMonacoEditorComponent = fixture.debugElement.componentInstance;
+      component.setMonacoNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.onEditorInitialized.subscribe(() => {
+          let language: any = {
+            id: 'mySpecialLanguage',
+            monarchTokensProvider: [
+                ['/\\[error.*/', 'custom-error'],
+                ['/\\[notice.*/', 'custom-notice'],
+                ['/\\[info.*/', 'custom-info'],
+                ['/\\[[a-zA-Z 0-9:]+\\]/', 'custom-date'],
+            ],
+            customTheme: {
+              id: 'myCustomTheme',
+              theme: {
+                base: 'vs-dark',
+                inherit: true,
+                rules: [
+                  { token: 'custom-info', foreground: '808080' },
+                  { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
+                  { token: 'custom-notice', foreground: 'FFA500' },
+                  { token: 'custom-date', foreground: '008800' },
+                ],
+              },
+            },
+            monarchTokensProviderCSS: `
+              .monaco-editor .token.custom-info {
+                color: grey;
+              }
+              .monaco-editor .token.custom-error {
+                color: red;
+                font-weight: bold;
+                font-size: 1.2em;
+              }
+              .monaco-editor .token.custom-notice {
+                color: orange;
+              }
+
+              .monaco-editor .token.custom-date {
+                color: green;
+              }
+            `,
+            completionItemProvider: [
+              {
+                label: 'simpleText',
+                kind: 'monaco.languages.CompletionItemKind.Text',
+              }, {
+                label: 'testing',
+                kind: 'monaco.languages.CompletionItemKind.Keyword',
+                insertText: 'testing({{condition}})',
+              },
+              {
+                label: 'ifelse',
+                kind: 'monaco.languages.CompletionItemKind.Snippet',
+                insertText: [
+                  'if ({{condition}}) {',
+                  '\t{{}}',
+                  '} else {',
+                  '\t',
+                  '}',
+                ].join('\n'),
+                documentation: 'If-Else Statement',
+              },
+            ],
+          };
+          component.registerLanguage(language);
+          component.theme = 'myCustomTheme';
+          component.language = 'mySpecialLanguage';
+          component.onEditorLanguageChanged.subscribe(() => {
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+              expect(component.theme).toBe('myCustomTheme');
+              expect(component.language).toBe('mySpecialLanguage');
+              done();
+            });
+          });
+        });
+      });
+    })();
+  });
+
+});

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -253,9 +253,9 @@ export class TdMonacoEditorComponent implements OnInit {
     // take the html content for the webview and base64 encode it and use as the src tag
     this._webview.setAttribute('src', 'data:text/html;base64,' + window.btoa(monacoHTML));
     this._webview.setAttribute('style', 'display:inline-flex; width:100%; height:100%');
-     this._webview.addEventListener('dom-ready', () => {
-        this._webview.openDevTools();
-     });
+    // this._webview.addEventListener('dom-ready', () => {
+    //    this._webview.openDevTools();
+    // });
 
     // Process the data from the webview
     this._webview.addEventListener('ipc-message', (event: any) => {

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -122,6 +122,11 @@ export class TdMonacoEditorComponent implements OnInit {
     return this._theme;
   }
 
+/**
+ * setMonacoNodeModuleDirOverride function that overrides where to look
+ * for the monaco editor node_module. Used in tests or anywhere that the
+ * node_modules are not in the expected location.
+ */
   setMonacoNodeModuleDirOverride(dirOverride: string): void {
       this._monacoNodeModuleDirOverride = dirOverride;
       this._appPath = dirOverride;

--- a/src/platform/monaco-editor/monaco-editor.component.ts
+++ b/src/platform/monaco-editor/monaco-editor.component.ts
@@ -18,10 +18,28 @@ export class TdMonacoEditorComponent implements OnInit {
   private _theme: string = 'vs';
   private _language: string = 'javascript';
   private _subject: Subject<string> = new Subject();
-
   private _monacoInnerContainer: string = 'monacoInnerContainer' + uniqueCounter++;
+  private _monacoNodeModuleDirOverride: string = '';
 
   @ViewChild('monacoContainer') _monacoContainer: ElementRef;
+
+ /**
+  * editorInitialized: function($event)
+  * Event emitted when editor is first initialized
+  */
+  @Output('editorInitialized') onEditorInitialized: EventEmitter<void> = new EventEmitter<void>();
+
+ /**
+  * editorConfigurationChanged: function($event)
+  * Event emitted when editor's configuration changes
+  */
+  @Output('editorConfigurationChanged') onEditorConfigurationChanged: EventEmitter<void> = new EventEmitter<void>();
+
+ /**
+  * editorLanguageChanged: function($event)
+  * Event emitted when editor's Language changes
+  */
+  @Output('editorLanguageChanged') onEditorLanguageChanged: EventEmitter<void> = new EventEmitter<void>();
 
  /**
   * editorValueChange: function($event)
@@ -104,6 +122,11 @@ export class TdMonacoEditorComponent implements OnInit {
     return this._theme;
   }
 
+  setMonacoNodeModuleDirOverride(dirOverride: string): void {
+      this._monacoNodeModuleDirOverride = dirOverride;
+      this._appPath = dirOverride;
+  }
+
   ngOnInit(): void {
     let monacoHTML: string = `<!DOCTYPE html>
         <html style="height:100%">
@@ -111,7 +134,7 @@ export class TdMonacoEditorComponent implements OnInit {
             <meta http-equiv="X-UA-Compatible" content="IE=edge" />
             <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
             <link rel="stylesheet" data-name="vs/editor/editor.main" 
-                href="file:///node_modules/monaco-editor/min/vs/editor/editor.main.css">
+                href="file://${this._monacoNodeModuleDirOverride}/node_modules/monaco-editor/min/vs/editor/editor.main.css">
         </head>
         <body style="height:100%;width: 100%;margin: 0;padding: 0;overflow: hidden;">
         <div id="${this._monacoInnerContainer}" style="width:100%;height:100%;${this._editorStyle}"></div>
@@ -119,7 +142,7 @@ export class TdMonacoEditorComponent implements OnInit {
             // Get the ipcRenderer of electron for communication
             const {ipcRenderer} = require('electron');
         </script>
-        <script src="file:///node_modules/monaco-editor/min/vs/loader.js"></script>
+        <script src="file://${this._monacoNodeModuleDirOverride}/node_modules/monaco-editor/min/vs/loader.js"></script>
         <script>
             var editor;
             var theme = '${this._theme}';
@@ -139,6 +162,7 @@ export class TdMonacoEditorComponent implements OnInit {
                 editor.getModel().onDidChangeContent( (e)=> {
                     ipcRenderer.sendToHost("onEditorContentChange", editor.getValue());
                 });
+                ipcRenderer.sendToHost("onEditorInitialized", '');
             });
 
             // return back the value in the editor to the mainview
@@ -154,6 +178,7 @@ export class TdMonacoEditorComponent implements OnInit {
             // set the options of the editor from what was sent from the mainview
             ipcRenderer.on('setEditorOptions', function(event, data){
                 editor.updateOptions(data);
+                ipcRenderer.sendToHost("onEditorConfigurationChanged", '');
             });
 
             // set the language of the editor from what was sent from the mainview
@@ -165,6 +190,8 @@ export class TdMonacoEditorComponent implements OnInit {
                     language: data,
                     theme: theme,
                 });
+                ipcRenderer.sendToHost("onEditorConfigurationChanged", '');
+                ipcRenderer.sendToHost("onEditorLanguageChanged", '');
             });
 
             // register a new language with editor
@@ -202,6 +229,8 @@ export class TdMonacoEditorComponent implements OnInit {
                 css.type = "text/css";
                 css.innerHTML = data.monarchTokensProviderCSS;
                 document.body.appendChild(css);
+
+                ipcRenderer.sendToHost("onEditorConfigurationChanged", '');
             });
 
             // need to manually resize the editor any time the window size
@@ -224,9 +253,9 @@ export class TdMonacoEditorComponent implements OnInit {
     // take the html content for the webview and base64 encode it and use as the src tag
     this._webview.setAttribute('src', 'data:text/html;base64,' + window.btoa(monacoHTML));
     this._webview.setAttribute('style', 'display:inline-flex; width:100%; height:100%');
-    // this._webview.addEventListener('dom-ready', () => {
-    //    this._webview.openDevTools();
-    // });
+     this._webview.addEventListener('dom-ready', () => {
+        this._webview.openDevTools();
+     });
 
     // Process the data from the webview
     this._webview.addEventListener('ipc-message', (event: any) => {
@@ -239,6 +268,12 @@ export class TdMonacoEditorComponent implements OnInit {
         } else if (event.channel === 'onEditorContentChange') {
             this._value = event.args[0];
             this.onEditorValueChange.emit(undefined);
+        } else if (event.channel === 'onEditorInitialized') {
+            this.onEditorInitialized.emit(undefined);
+        } else if (event.channel === 'onEditorConfigurationChanged') {
+            this.onEditorConfigurationChanged.emit(undefined);
+        } else if (event.channel === 'onEditorLanguageChanged') {
+            this.onEditorLanguageChanged.emit(undefined);
         }
     });
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,4 @@
-import './polyfills.ts';
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';
@@ -6,28 +6,28 @@ import 'zone.js/dist/sync-test';
 import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
+import 'hammerjs';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
 declare var require: any;
 
 // Prevent Karma from running prematurely.
-__karma__.loaded = function (): void { /* noop */ };
+__karma__.loaded = function (): void {/* empty */};
 
-Promise.all([
-  System.import('@angular/core/testing'),
-  System.import('@angular/platform-browser-dynamic/testing'),
-])
-  // First, initialize the Angular testing environment.
-  .then(([testing, testingBrowser]: any[]) => {
-    testing.getTestBed().initTestEnvironment(
-      testingBrowser.BrowserDynamicTestingModule,
-      testingBrowser.platformBrowserDynamicTesting(),
-    );
-  })
-  // Then we find all the tests.
-  .then(() => require.context('./', true, /\.spec\.ts/))
-  // And load the modules.
-  .then((context: any) => context.keys().map(context))
-  // Finally, start Karma to run the tests.
-  .then(__karma__.start, __karma__.error);
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);
+// Then we find all the tests.
+const context: any = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);
+// Finally, start Karma to run the tests.
+__karma__.start();


### PR DESCRIPTION
## Description

Ability to run Karma unit tests in Covalent-Electron against ng components, native node_modules, and external node_modules

### What's included?

- .angular-cli.json
- karma.conf.js
- karma.shim.js
- package.json
- README.md
- src/platform/file-select/file-select.component.spec.ts
- src/platform/monaco-editor/monaco-editor.component.spec.ts
- scripts/reload.js
- src/electron-load.js
- src/platform/file-select/file-select.component.spec.ts
- src/platform/monaco-editor/monaco-editor.component.ts

#### Test Steps

- [ ] checkout branch feature/unit-tests
- [ ] npm run reinstall
- [ ] npm run test
- [ ] See Electron launch and run tests
- [ ] See them run successfully: `Executed 8 of 8 SUCCESS`
