### PR TITLE
Setting unit tests to only run one time with npm run test and updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 ## Covalent-Electron is the Electron Platform to build desktop apps using Covalent and Electron
 
 [![Build Status](https://travis-ci.org/Teradata/covalent.svg?branch=develop)](https://travis-ci.org/Teradata/covalent-electron)
-[![npm version](https://badge.fury.io/js/%40covalent%2Fcore.svg)](https://badge.fury.io/js/%40covalent%2Fcore)
 [![Join the chat at https://gitter.im/Teradata/covalent](https://badges.gitter.im/Teradata/covalent.svg)](https://gitter.im/Teradata/covalent?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Dependency Status](https://dependencyci.com/github/Teradata/covalent/badge)](https://dependencyci.com/github/Teradata/covalent)
 
 <img alt="Covalent" src="https://cdn.rawgit.com/Teradata/covalent-electron/develop/src/app/assets/icons/covalent-and-electron.svg" width="503">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Covalent-Electron is the Electron Platform to build desktop apps using Covalent and Electron
 
-[![Build Status](https://travis-ci.org/Teradata/covalent.svg?branch=develop)](https://travis-ci.org/Teradata/covalent)
+[![Build Status](https://travis-ci.org/Teradata/covalent.svg?branch=develop)](https://travis-ci.org/Teradata/covalent-electron)
 [![npm version](https://badge.fury.io/js/%40covalent%2Fcore.svg)](https://badge.fury.io/js/%40covalent%2Fcore)
 [![Join the chat at https://gitter.im/Teradata/covalent](https://badges.gitter.im/Teradata/covalent.svg)](https://gitter.im/Teradata/covalent?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Dependency Status](https://dependencyci.com/github/Teradata/covalent/badge)](https://dependencyci.com/github/Teradata/covalent)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "semver": "5.2.0",
     "ts-node": "~2.0.0",
     "tslint": "^4.5.1",
-    "typescript": "2.1.6",
+    "typescript": "2.3.2",
     "electron": "^1.6.6",
     "electron-packager": "^8.6.0",
     "electron-connect": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "gulp copy --option noreload",
     "package": "npm run ngbuild && npm run build && npm run npm-install && node \"./node_modules/electron-packager/cli.js\" dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite",
     "live-reload": "gulp watch",
-    "test": "npm run build && npm run npm-install && ng test"
+    "test": "npm run build && npm run npm-install && ng test --code-coverage --single-run --sourcemap=false"
   },
   "engines": {
     "node": ">4.4 < 7",


### PR DESCRIPTION
Updated package.json with `ng test --code-coverage --single-run --sourcemap=false` so unit tests to only run one time with npm run test

and

updating readme to point to covalent-electron build status and updating readme to not have npm or dependency links