### PR TITLE
chore(): upgrade covalent/code-editor to 1.0.0-alpha.6-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@covalent/highlight": "1.0.0-beta.3-2",
     "@covalent/http": "1.0.0-beta.3-2",
     "@covalent/markdown": "1.0.0-beta.3-2",
-    "@covalent/code-editor": "^1.0.0-alpha.3",
+    "@covalent/code-editor": "^1.0.0-alpha.6",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@covalent/highlight": "1.0.0-beta.3-2",
     "@covalent/http": "1.0.0-beta.3-2",
     "@covalent/markdown": "1.0.0-beta.3-2",
-    "@covalent/code-editor": "^1.0.0-alpha.6-3",
+    "@covalent/code-editor": "^1.0.0-alpha.6-4",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@covalent/highlight": "1.0.0-beta.3-2",
     "@covalent/http": "1.0.0-beta.3-2",
     "@covalent/markdown": "1.0.0-beta.3-2",
-    "@covalent/code-editor": "^1.0.0-alpha.6-2",
+    "@covalent/code-editor": "^1.0.0-alpha.6-3",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@covalent/highlight": "1.0.0-beta.3-2",
     "@covalent/http": "1.0.0-beta.3-2",
     "@covalent/markdown": "1.0.0-beta.3-2",
-    "@covalent/code-editor": "^1.0.0-alpha.6-1",
+    "@covalent/code-editor": "^1.0.0-alpha.6-2",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Upgrade Covalent-Electron to use Code Editor 1.0.0-alpha.6-4

### What's included?

- modified:   package.json

#### Test Steps

- [ ] `rm -rf node_modules` (if you have previously built)
- [ ]  `npm i`
- [ ]  `npm run live-reload`
- [ ] traverse down file chooser in left bar and select a file
- [ ] see the file display in editor

- [ ] `npm run test` works
- [ ] `npm run lint` works