### PR TITLE
fix(live-reload): Fix second run of live-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "reinstall": "rimraf node_modules dist dist-ng dist-app && npm i",
     "build": "gulp copy --option noreload",
     "package": "npm run ngbuild && npm run build && npm run npm-install && node \"./node_modules/electron-packager/cli.js\" dist Covalent --icon=src/app/assets/ico/icon.icns --out=dist-app --overwrite",
-    "live-reload": "gulp watch",
+    "live-reload": "rimraf ./dist && rimraf ./dist-ng && gulp watch",
     "test": "npm run build && npm run npm-install && ng test --code-coverage --single-run --sourcemap=false"
   },
   "engines": {


### PR DESCRIPTION
## Description

The 2nd time running live-reload fails when the dist directories are there. Cleaning those up before running

### What's included?

- modified:   package.json

#### Test Steps

- [ ] Checkout branch
- [ ] npm run live-reload
- [ ] see app launches
- [ ] close app
- [ ] npm run live-reload
- [ ] see app launches

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.